### PR TITLE
use slurm exporter container 0.3.0

### DIFF
--- a/specs/default/cluster-init/scripts/10_node_exporter.sh
+++ b/specs/default/cluster-init/scripts/10_node_exporter.sh
@@ -47,13 +47,7 @@ function install_node_exporter() {
     mkdir -pv /etc/sysconfig
 
     # Copy node exporter configuration file
-    # TODO: Customize the node_exporter configuration file based on node type
-    # TODO: Compute nodes will have reduced metrics
     cp -v $SPEC_FILE_ROOT/sysconfig.node_exporter /etc/sysconfig/node_exporter
-
-    # Create textfile_collector directory
-    #mkdir -pv /var/lib/node_exporter/textfile_collector
-    #chown node_exporter:node_exporter /var/lib/node_exporter/textfile_collector
 
     # Enable and start node exporter service
     systemctl daemon-reload
@@ -62,6 +56,11 @@ function install_node_exporter() {
 }
 
 function add_scraper() {
+    # If node_exporter is already configured, do not add it again
+    if grep -q "node_exporter" $PROM_CONFIG; then
+        echo "Node Exporter is already configured in Prometheus"
+        return 0
+    fi 
     INSTANCE_NAME=$(hostname)
 
     yq eval-all '. as $item ireduce ({}; . *+ $item)' $PROM_CONFIG $SPEC_FILE_ROOT/node_exporter.yml > tmp.yml

--- a/specs/default/cluster-init/scripts/60_slurm_exporter.sh
+++ b/specs/default/cluster-init/scripts/60_slurm_exporter.sh
@@ -151,14 +151,6 @@ install_slurm_exporter() {
         echo "Slurm Exporter is not running"
         exit 1
     fi
-
-    # Check if metrics are available
-    if curl -s http://localhost:${SLURM_EXPORTER_PORT}/metrics | grep -q "slurm_node_total"; then
-        echo "Slurm Exporter metrics are available"
-    else
-        echo "Slurm Exporter metrics are not available"
-        exit 1
-    fi
 }
 
 function add_scraper() {
@@ -178,4 +170,12 @@ if is_scheduler ; then
     install_slurm_exporter
     install_yq
     add_scraper
+
+    # Check if metrics are available, can only be done after prometheus has been configured and restarted
+    if curl -s http://localhost:${SLURM_EXPORTER_PORT}/metrics | grep -q "slurm_node_total"; then
+        echo "Slurm Exporter metrics are available"
+    else
+        echo "Slurm Exporter metrics are not available"
+        exit 1
+    fi    
 fi

--- a/specs/default/cluster-init/scripts/60_slurm_exporter.sh
+++ b/specs/default/cluster-init/scripts/60_slurm_exporter.sh
@@ -172,7 +172,7 @@ if is_scheduler ; then
     add_scraper
 
     # Check if metrics are available, can only be done after prometheus has been configured and restarted
-    if curl -s http://localhost:${SLURM_EXPORTER_PORT}/metrics | grep -q "slurm_node_total"; then
+    if curl -s http://localhost:${SLURM_EXPORTER_PORT}/metrics | grep -q "slurm_nodes_total"; then
         echo "Slurm Exporter metrics are available"
     else
         echo "Slurm Exporter metrics are not available"

--- a/specs/default/cluster-init/scripts/60_slurm_exporter.sh
+++ b/specs/default/cluster-init/scripts/60_slurm_exporter.sh
@@ -29,12 +29,20 @@ install_prerequisites() {
     # Restarting the slurm services here can cause problems
 
     # See: https://github.com/benmcollins/libjwt
-    if command -v apt-get &> /dev/null; then
-        apt-get install -y libjansson-dev libjwt-dev binutils
-    else 
-        dnf install -y libjansson-devel libjwt-dev binutils
-    fi
-
+    . /etc/os-release
+    case $ID in
+        ubuntu)
+            DEBIAN_FRONTEND=noninteractive apt-get install -y libjansson-dev libjwt-dev binutils
+            ;;
+        rocky|almalinux|centos)
+            dnf install -y jansson-devel libjwt-devel binutils
+            ;;
+        *)
+            echo "Unsupported OS: $ID"
+            exit 1
+            ;;
+    esac
+    
     # Configure JWT and slurmrestd
 
     # Create a local key
@@ -96,11 +104,20 @@ EOF
 build_slurm_exporter() {
     # This function is not used anymore, but kept for reference
     echo "Building Slurm Exporter..."
-    if command -v apt-get &> /dev/null; then
-        apt-get install -y git golang-go
-    else 
-        dnf install -y git golang-go
-    fi
+    . /etc/os-release
+    case $ID in
+        ubuntu)
+            DEBIAN_FRONTEND=noninteractive apt-get install -y git golang-go
+            ;;
+        rocky|almalinux|centos)
+            dnf install -y git golang-go
+            ;;
+        *)
+            echo "Unsupported OS: $ID"
+            exit 1
+            ;;
+    esac
+
     # Build the exporter
     pushd /tmp
     rm -rf slurm-exporter


### PR DESCRIPTION
- do not build the container and do not install build tools
- use published container ghcr.io/slinkyproject/slurm-exporter:0.3.0
- remove per user metrics option as it's always there
- add the test for checking if metrics are published after the configuration of prometheus
- add a 20s wait before checking if metrics exists as prom is configured to scrap every 15s
- check of scrap config is already there before adding it