### PR TITLE
Fixed issue where regex for instance was taking a substring of instance and causing multiple instances to be automatically selected

### DIFF
--- a/infra/dashboards/combined_view.json
+++ b/infra/dashboards/combined_view.json
@@ -100,7 +100,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -108,7 +108,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_uname_info{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_uname_info{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -211,7 +211,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -289,7 +289,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -365,7 +365,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -374,7 +374,7 @@
           },
           "editorMode": "code",
           "expr": "100 - (node_filesystem_avail_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -448,7 +448,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -456,8 +456,10 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -531,7 +533,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -540,7 +542,7 @@
           },
           "editorMode": "code",
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -644,7 +646,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\" }[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -746,7 +748,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_cpu_frequency_hertz{instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"} / 1000000",
+          "expr": "node_cpu_frequency_hertz{instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"} / 1000000",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -850,7 +852,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\", cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -953,7 +955,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -1062,7 +1064,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -1165,7 +1167,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"}",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -1275,7 +1277,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"$instance\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -1286,7 +1288,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
@@ -1389,7 +1391,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"${instance}\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -1503,7 +1505,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_reads_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - reads completed",
           "range": true,
           "refId": "A"
@@ -1514,7 +1516,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_writes_completed_total{instance=\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - writes completed",
           "range": true,
           "refId": "B"
@@ -1628,7 +1630,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} -read",
           "range": true,
           "refId": "A"
@@ -1639,7 +1641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - write",
           "range": true,
           "refId": "B"
@@ -1753,7 +1755,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - {{operation}}s completed",
           "range": true,
           "refId": "A"
@@ -1764,7 +1766,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{export}} - {{operation}}s completed",
@@ -1880,7 +1882,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - read",
           "range": true,
           "refId": "A"
@@ -1891,7 +1893,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - write",
           "range": true,
           "refId": "B"
@@ -1971,7 +1973,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -1979,7 +1981,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=\"$instance\", cluster=\"$cluster\", gpu=\"0\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=\"0\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2071,7 +2073,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2079,7 +2081,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(dcgm_fi_dev_gpu_util{instance=~\"$instance\", cluster=\"$cluster\"})",
+          "expr": "avg(dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2145,7 +2147,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2153,7 +2155,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_power_usage{instance=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{instance=~\"$instance\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
+          "expr": "avg ((dcgm_fi_dev_power_usage{instance=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{instance=~\"^$instance$\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -2219,7 +2221,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2227,7 +2229,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_gpu_temp{instance=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{instance=~\"$instance\",cluster=\"$cluster\"}) * 100) ",
+          "expr": "avg ((dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{instance=~\"^$instance$\",cluster=\"$cluster\"}) * 100) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2308,7 +2310,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2316,7 +2318,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{instance=\"$instance\", cluster=\"$cluster\"})",
+          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{instance=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "{{gpu}}",
           "range": true,
           "refId": "A"
@@ -2422,7 +2424,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2528,7 +2530,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2631,7 +2633,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_sm_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_sm_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2734,7 +2736,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2838,7 +2840,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2942,7 +2944,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3046,7 +3048,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3149,7 +3151,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"} / 10^3",
+          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"} / 10^3",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3254,7 +3256,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -3263,7 +3265,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -3475,7 +3477,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -3485,7 +3487,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -3704,7 +3706,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3870,7 +3872,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4035,7 +4037,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4201,7 +4203,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4337,7 +4339,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4439,7 +4441,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4559,7 +4561,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_active{instance=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4666,7 +4668,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_occupancy{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_occupancy{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4773,7 +4775,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_tensor_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_tensor_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4880,7 +4882,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp16_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp16_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4987,7 +4989,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp32_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp32_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5094,7 +5096,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp64_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp64_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5212,7 +5214,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -5223,7 +5225,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -5363,7 +5365,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_infiniband_physical_state_id{instance=~\"$instance\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
+          "expr": "node_infiniband_physical_state_id{instance=~\"^$instance$\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5465,7 +5467,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=\"$instance\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=~\"^$instance$\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5582,7 +5584,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{device}} - receive",
           "range": true,
@@ -5594,7 +5596,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$instance\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{device}} - transmit",
@@ -5697,7 +5699,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5798,7 +5800,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5899,7 +5901,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6000,7 +6002,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6101,7 +6103,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6220,7 +6222,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -6230,7 +6232,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -6452,7 +6454,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6605,7 +6607,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -6616,7 +6618,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -6750,7 +6752,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6916,7 +6918,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"$instance\", cluster=\"$cluster\",gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"^$instance$\", cluster=\"$cluster\",gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -7143,8 +7145,8 @@
       {
         "current": {
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}"
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -7170,8 +7172,8 @@
       {
         "current": {
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}"
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -7197,8 +7199,8 @@
       {
         "current": {
           "selected": false,
-          "text": "sat111102202007",
-          "value": "sat111102202007"
+          "text": "sat111100202001",
+          "value": "sat111100202001"
         },
         "datasource": {
           "type": "prometheus",
@@ -7239,6 +7241,6 @@
   "timezone": "browser",
   "title": "Combined Node, IB, GPU & NVLink Metrics Dashboard",
   "uid": "9Qxi6EuNVsx",
-  "version": 8,
+  "version": 1,
   "weekStart": ""
 }

--- a/infra/dashboards/combined_view_without_gpu_profiling.json
+++ b/infra/dashboards/combined_view_without_gpu_profiling.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "Combined Node, IB, GPU & NVLink Metrics Dashboard (w/o GPU Profiling)",
+  "description": "Combined Node, IB, GPU & NVLink Metrics Dashboard",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -100,7 +100,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -108,7 +108,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_uname_info{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_uname_info{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -211,7 +211,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -289,7 +289,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -365,7 +365,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -374,7 +374,7 @@
           },
           "editorMode": "code",
           "expr": "100 - (node_filesystem_avail_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -448,7 +448,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -456,8 +456,10 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -531,7 +533,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -540,7 +542,7 @@
           },
           "editorMode": "code",
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -644,7 +646,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\" }[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -746,7 +748,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_cpu_frequency_hertz{instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"} / 1000000",
+          "expr": "node_cpu_frequency_hertz{instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"} / 1000000",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -850,7 +852,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\", cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -953,7 +955,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -1062,7 +1064,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -1165,7 +1167,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"}",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -1275,7 +1277,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"$instance\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -1286,7 +1288,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
@@ -1389,7 +1391,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"${instance}\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -1503,7 +1505,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_reads_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - reads completed",
           "range": true,
           "refId": "A"
@@ -1514,7 +1516,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_writes_completed_total{instance=\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - writes completed",
           "range": true,
           "refId": "B"
@@ -1628,7 +1630,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} -read",
           "range": true,
           "refId": "A"
@@ -1639,7 +1641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - write",
           "range": true,
           "refId": "B"
@@ -1753,7 +1755,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - {{operation}}s completed",
           "range": true,
           "refId": "A"
@@ -1764,7 +1766,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{export}} - {{operation}}s completed",
@@ -1880,7 +1882,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - read",
           "range": true,
           "refId": "A"
@@ -1891,7 +1893,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - write",
           "range": true,
           "refId": "B"
@@ -1971,7 +1973,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -1979,7 +1981,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=\"$instance\", cluster=\"$cluster\", gpu=\"0\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=\"0\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2071,7 +2073,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2079,7 +2081,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(dcgm_fi_dev_gpu_util{instance=~\"$instance\", cluster=\"$cluster\"})",
+          "expr": "avg(dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2145,7 +2147,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2153,7 +2155,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_power_usage{instance=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{instance=~\"$instance\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
+          "expr": "avg ((dcgm_fi_dev_power_usage{instance=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{instance=~\"^$instance$\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -2219,7 +2221,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2227,7 +2229,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_gpu_temp{instance=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{instance=~\"$instance\",cluster=\"$cluster\"}) * 100) ",
+          "expr": "avg ((dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{instance=~\"^$instance$\",cluster=\"$cluster\"}) * 100) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2308,7 +2310,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2316,7 +2318,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{instance=\"$instance\", cluster=\"$cluster\"})",
+          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{instance=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "{{gpu}}",
           "range": true,
           "refId": "A"
@@ -2422,7 +2424,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2528,7 +2530,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2631,7 +2633,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_sm_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_sm_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2734,7 +2736,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2838,7 +2840,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2942,7 +2944,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3046,7 +3048,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3149,7 +3151,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"} / 10^3",
+          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"} / 10^3",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3254,7 +3256,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -3263,7 +3265,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -3475,7 +3477,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -3485,7 +3487,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -3704,7 +3706,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3870,7 +3872,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4035,7 +4037,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4201,7 +4203,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4337,7 +4339,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4439,7 +4441,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4577,7 +4579,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_infiniband_physical_state_id{instance=~\"$instance\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
+          "expr": "node_infiniband_physical_state_id{instance=~\"^$instance$\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -4679,7 +4681,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=\"$instance\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=~\"^$instance$\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -4796,7 +4798,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{device}} - receive",
           "range": true,
@@ -4808,7 +4810,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$instance\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{device}} - transmit",
@@ -4911,7 +4913,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5012,7 +5014,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5113,7 +5115,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5214,7 +5216,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5315,7 +5317,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5434,7 +5436,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -5444,7 +5446,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -5666,7 +5668,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5819,7 +5821,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -5830,7 +5832,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -5964,7 +5966,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6130,7 +6132,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"$instance\", cluster=\"$cluster\",gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"^$instance$\", cluster=\"$cluster\",gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6357,8 +6359,8 @@
       {
         "current": {
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}"
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -6384,8 +6386,8 @@
       {
         "current": {
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",dcgm_fi_driver_version=\"560.35.03\",device=\"nvidia0\",gpu=\"0\",hostname=\"697d062e3d3c\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111102202007\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-c670543c-6737-69cf-7d5c-4e41d9c55e59\"}"
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"ccw_05051453/ccw\",device=\"nvidia0\",gpu=\"0\",hostname=\"6f6bfae03eac\",instance=\"ccw-gpu-2\",job=\"dcgm_exporter\",modelname=\"nvidia a100 80gb pcie\",pci_bus_id=\"00000001:00:00.0\",physical_host=\"sat111100202001\",subscription=\"e3786699-5116-4dc9-82c6-a8aab043fb85\",uuid=\"gpu-1733d42c-5f9a-2390-658b-caaa75b982a9\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -6411,8 +6413,8 @@
       {
         "current": {
           "selected": false,
-          "text": "sat111102202007",
-          "value": "sat111102202007"
+          "text": "sat111100202001",
+          "value": "sat111100202001"
         },
         "datasource": {
           "type": "prometheus",

--- a/infra/dashboards/gpu_device.json
+++ b/infra/dashboards/gpu_device.json
@@ -143,7 +143,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -249,7 +249,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_copy_util{instance=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -369,7 +369,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_sm_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_sm_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -472,7 +472,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_clock{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_clock{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -593,7 +593,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -697,7 +697,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -818,7 +818,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -921,7 +921,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"} / 10^3",
+          "expr": "dcgm_fi_dev_total_energy_consumption{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"} / 10^3",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1044,7 +1044,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -1053,7 +1053,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -1293,7 +1293,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1459,7 +1459,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1624,7 +1624,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1790,7 +1790,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1963,7 +1963,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -1973,7 +1973,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -2162,7 +2162,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2264,7 +2264,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2312,7 +2312,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           }
@@ -2382,7 +2383,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.2.8+security-01",
+      "pluginVersion": "11.2.8",
       "targets": [
         {
           "datasource": {
@@ -2392,7 +2393,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -2614,7 +2615,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2767,7 +2768,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -2778,7 +2779,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -2912,7 +2913,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3078,7 +3079,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3151,7 +3152,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "ccw_05051453/ccw",
           "value": "ccw_05051453/ccw"
         },
@@ -3242,7 +3243,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/infra/dashboards/gpu_profiling.json
+++ b/infra/dashboards/gpu_profiling.json
@@ -25,8 +25,8 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "grafana-azure-monitor-datasource",
-        "uid": "azure-monitor-oob"
+        "type": "prometheus",
+        "uid": "${Datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -39,8 +39,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "grafana-azure-monitor-datasource",
-            "uid": "azure-monitor-oob"
+            "type": "prometheus",
+            "uid": "${Datasource}"
           },
           "refId": "A"
         }
@@ -146,7 +146,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -253,7 +253,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_occupancy{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_occupancy{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -360,7 +360,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_tensor_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_tensor_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -467,7 +467,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp16_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp16_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -574,7 +574,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp32_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp32_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -681,7 +681,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp64_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp64_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -693,8 +693,8 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "grafana-azure-monitor-datasource",
-        "uid": "azure-monitor-oob"
+        "type": "prometheus",
+        "uid": "${Datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -707,8 +707,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "grafana-azure-monitor-datasource",
-            "uid": "azure-monitor-oob"
+            "type": "prometheus",
+            "uid": "${Datasource}"
           },
           "refId": "A"
         }
@@ -814,7 +814,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_dram_active{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_dram_active{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -826,8 +826,8 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "grafana-azure-monitor-datasource",
-        "uid": "azure-monitor-oob"
+        "type": "prometheus",
+        "uid": "${Datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -840,8 +840,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "grafana-azure-monitor-datasource",
-            "uid": "azure-monitor-oob"
+            "type": "prometheus",
+            "uid": "${Datasource}"
           },
           "refId": "A"
         }
@@ -959,7 +959,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -970,7 +970,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -984,8 +984,8 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "grafana-azure-monitor-datasource",
-        "uid": "azure-monitor-oob"
+        "type": "prometheus",
+        "uid": "${Datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -998,8 +998,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "grafana-azure-monitor-datasource",
-            "uid": "azure-monitor-oob"
+            "type": "prometheus",
+            "uid": "${Datasource}"
           },
           "refId": "A"
         }
@@ -1116,7 +1116,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -1127,7 +1127,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{instance=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -1167,7 +1167,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "ccw_05051453/ccw",
           "value": "ccw_05051453/ccw"
         },
@@ -1195,7 +1195,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "ccw-gpu-2",
           "value": "ccw-gpu-2"
         },

--- a/infra/dashboards/infiniband.json
+++ b/infra/dashboards/infiniband.json
@@ -154,7 +154,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{device}} - receive",
           "range": true,
@@ -166,7 +166,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{device}} - transmit",
@@ -310,7 +310,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_infiniband_physical_state_id{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}",
+          "expr": "node_infiniband_physical_state_id{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -412,7 +412,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=\"$instance\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=~\"^$instance$\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -513,7 +513,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -614,7 +614,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -673,7 +673,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -714,7 +715,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -773,7 +774,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -814,7 +816,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"$instance\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"^$instance$\", device!=\"mlx5_an0\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -873,7 +875,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -914,7 +917,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"$instance\", device!=\"mlx5_an0\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"^$instance$\", device!=\"mlx5_an0\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -981,8 +984,8 @@
       {
         "current": {
           "selected": true,
-          "text": "ccw-hpc-2",
-          "value": "ccw-hpc-2"
+          "text": "ccw-hpc-1",
+          "value": "ccw-hpc-1"
         },
         "datasource": {
           "type": "prometheus",

--- a/infra/dashboards/node.json
+++ b/infra/dashboards/node.json
@@ -137,7 +137,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (instance, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"}[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (instance, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"}[$__rate_interval]))))",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -239,7 +239,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_cpu_frequency_hertz{instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"} / 1000000",
+          "expr": "node_cpu_frequency_hertz{instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"} / 1000000",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -343,7 +343,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "scalar(node_load1{cluster=\"$cluster\", instance=\"$instance\"}) * 100 / count(count(node_cpu_seconds_total{cluster=\"$cluster\", instance=\"$instance\"}) by (cpu))",
+          "expr": "scalar(node_load1{cluster=\"$cluster\", instance=~\"^$instance$\"}) * 100 / count(count(node_cpu_seconds_total{cluster=\"$cluster\", instance=~\"^$instance$\"}) by (cpu))",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -460,7 +460,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\",cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\",cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -565,7 +565,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\",cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\",cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\",cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\",cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -667,7 +667,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -790,7 +790,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -801,7 +801,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
@@ -917,7 +917,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=\"$instance\",device!~\"rootfs\"} - node_filesystem_avail_bytes{instance=\"$instance\",device!~\"rootfs\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$instance$\",device!~\"rootfs\",cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=~\"^$instance$\",device!~\"rootfs\",cluster=\"$cluster\"}",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -1031,7 +1031,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_reads_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - reads completed",
           "range": true,
           "refId": "A"
@@ -1042,7 +1042,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\",device=~\"$diskdevices\"}[$__rate_interval])",
+          "expr": "irate(node_disk_writes_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - writes completed",
           "range": true,
           "refId": "B"
@@ -1143,7 +1143,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -1257,7 +1257,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - read",
           "range": true,
           "refId": "A"
@@ -1268,7 +1268,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - write",
           "range": true,
           "refId": "B"
@@ -1395,7 +1395,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - {{operation}}s completed",
           "range": true,
           "refId": "A"
@@ -1406,7 +1406,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^WRITE$\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{export}} - {{operation}}s completed",
@@ -1522,7 +1522,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - read",
           "range": true,
           "refId": "A"
@@ -1533,7 +1533,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - write",
           "range": true,
           "refId": "B"
@@ -1599,8 +1599,8 @@
       {
         "current": {
           "selected": true,
-          "text": "ccw-hpc-2",
-          "value": "ccw-hpc-2"
+          "text": "ccw-gpu-2",
+          "value": "ccw-gpu-2"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Issue: Querying for ccw-gpu-1 was also returning results for ccw-gpu-11 and ccw-gpu-101
Cause: Using instance=~"$instance" without anchoring performed substring matching instead of exact matching
Solution: Using either:

instance="$instance" (exact match)
instance=~"^$instance$" (anchored regex)

The regex was matching any instance name containing "ccw-gpu-1" as a substring, rather than matching it exactly.