### PR TITLE
DCGM exporter container does not require modifying host packages.

### DIFF
--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -17,25 +17,6 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
 fi
 
 install_dcgm_exporter() {
-    # Install NVIDIA DCGM
-    # https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html
-    CUDA_VERSION=$(nvidia-smi | sed -E -n 's/.*CUDA Version: ([0-9]+)[.].*/\1/p')
-    . /etc/os-release
-    case $ID in
-        ubuntu)
-            DEBIAN_FRONTEND=noninteractive apt-get install --yes --install-recommends datacenter-gpu-manager-4-cuda${CUDA_VERSION}
-            ;;
-        rocky|almalinux|centos)
-            dnf install --assumeyes --setopt=install_weak_deps=True datacenter-gpu-manager-4-cuda${CUDA_VERSION} --allowerasing
-            ;;
-        *)
-            echo "Unsupported OS: $ID"
-            exit 1
-            ;;
-    esac
-
-    systemctl daemon-reload
-    systemctl restart nvidia-dcgm.service
     
     # Run DCGM Exporter in a container
     docker run -v $SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv \


### PR DESCRIPTION
DCGM exporter container already contains everything it needs to export metrics. There are numerous issues with needlessly installing DCGM packages -
- it could break healthagent as it takes an API level dependency on DCGM.
- Needlessly starting nvidia-dcgm service causes problems and is not necessary when DCGM exporter is run in a container. This is already breaking healthagent in BFL environment. 
- Container already contains the packages. (it does not even need the cuda12 package) so it just slows down cluster-init.