### PR TITLE
improve deployment scripts

### DIFF
--- a/infra/add_dashboards.sh
+++ b/infra/add_dashboards.sh
@@ -15,8 +15,13 @@ fi
 
 FOLDER_NAME="Azure CycleCloud"
 DASHBOARD_FOLDER=$THIS_DIR/dashboards
-# Create Grafana dashobards folders
-az grafana folder create --name $GRAFANA_NAME --resource-group $RESOURCE_GROUP_NAME --title "$FOLDER_NAME"
+# Create Grafana dashboards folders
+az grafana folder show -n $GRAFANA_NAME -g $RESOURCE_GROUP_NAME --folder "$FOLDER_NAME" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "$FOLDER_NAME folder does not exist. Creating it."
+  az grafana folder create --name $GRAFANA_NAME --resource-group $RESOURCE_GROUP_NAME --title "$FOLDER_NAME"
+fi
+
 
 # Single node dashboards
 az grafana dashboard import --name $GRAFANA_NAME --resource-group $RESOURCE_GROUP_NAME --folder "$FOLDER_NAME" --overwrite true --definition $DASHBOARD_FOLDER/node.json

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -22,7 +22,9 @@ if [ -z "$USER_OBJECT_ID" ]; then
   exit 1
 fi
 
-az deployment group create --resource-group $RESOURCE_GROUP_NAME --template-file $THIS_DIR/main.bicep --parameters location=$LOCATION userObjectId=$USER_OBJECT_ID > $THIS_DIR/outputs.json
+deploymentName="monitoring-deployment-$(date +%s)"
+# Start the deployment
+az deployment group create --resource-group $RESOURCE_GROUP_NAME -o json -n $deploymentName --template-file $THIS_DIR/main.bicep --parameters location=$LOCATION userObjectId=$USER_OBJECT_ID > $THIS_DIR/outputs.json
 if [ $? -ne 0 ]; then
   echo "Deployment failed."
   exit 1


### PR DESCRIPTION
- Add a unique deployment name to avoid collision at the subscription level
- when adding dashboards check if the folder already exists to allow rerunning the script