### PR TITLE
set prometheus data dir to /mnt

### DIFF
--- a/specs/default/cluster-init/files/prometheus.service
+++ b/specs/default/cluster-init/files/prometheus.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/opt/prometheus/prometheus --config.file=/opt/prometheus/prometheus.yml
+ExecStart=/opt/prometheus/prometheus --config.file=/opt/prometheus/prometheus.yml --storage.tsdb.path=/mnt/prometheus/data
 Restart=always
 RestartSec=15
 

--- a/specs/default/cluster-init/scripts/00_prometheus.sh
+++ b/specs/default/cluster-init/scripts/00_prometheus.sh
@@ -70,6 +70,8 @@ function install_prometheus() {
     sed -i -r "s|cluster_name|$CLUSTER_NAME|" $PROM_CONFIG
     sed -i -r "s/physical_host_name/$PHYS_HOST_NAME/" $PROM_CONFIG
 
+    # Create Prometheus data directory to avoid landing on default /data folder
+    mkdir -pv /mnt/prometheus/data
 
     # Enable and start prometheus service
     systemctl daemon-reload


### PR DESCRIPTION
by default Prom data dir is /data which conflict with the additional mount point.
Forcing the directory to be on /mnt/prometheus/data
