### PR TITLE
add -r flag to docker command to run dcgm_exporter

### DIFF
--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -20,8 +20,9 @@ install_dcgm_exporter() {
     
     # Run DCGM Exporter in a container
     docker run -v $SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p 9400:9400 \
-            nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04 -f /etc/dcgm-exporter/custom-counters.csv
+            -d --gpus all --net host --cap-add SYS_ADMIN --restart always -p 9400:9400 \
+            nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04 \ 
+            -r localhost:5555 -f /etc/dcgm-exporter/custom-counters.csv
 }
 
 function add_scraper() {


### PR DESCRIPTION
 include -r option to connect to remote hostengine at localhost:5555 to show injected errors through dcgmi