### PR TITLE
Revert "Merge pull request #32 from Azure/azreenzaman/dcgm-remote"

### DIFF
--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -20,9 +20,8 @@ install_dcgm_exporter() {
     
     # Run DCGM Exporter in a container
     docker run -v $SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv \
-            -d --gpus all --net host --cap-add SYS_ADMIN --restart always -p 9400:9400 \
-            nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04 \ 
-            -r localhost:5555 -f /etc/dcgm-exporter/custom-counters.csv
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p 9400:9400 \
+            nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04 -f /etc/dcgm-exporter/custom-counters.csv
 }
 
 function add_scraper() {


### PR DESCRIPTION
This reverts commit 1635c8e8a665766b96cee19397c95d9fc39db19e, reversing changes made to f8e4230f2bae469d573aeb20c36d6e0be188898f. 

@Aditi mentioned that adding -r to the dcgm_exporter will make the exporter reliant on the nvidia-dcgm service which can break the exporter if that service dies. Injecting errors is not required in a live production scenario so we can omit this. 