### PR TITLE
Improve robustness of dcgm-exporter install

### DIFF
--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Installs yq, dcgm-exporter, and prom config
+set -ex
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SPEC_FILE_ROOT="$script_dir/../files"
 PROM_CONFIG=/opt/prometheus/prometheus.yml
 DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04"
 DCGM_CONTAINER_NAME="dcgm-exporter"
-DCGM_PORT=9400
+DCGM_PORT=$(/opt/cycle/jetpack/bin/jetpack config cyclecloud.monitoring.dcgm_exporter_port 9400)
 
 source "$SPEC_FILE_ROOT/common.sh"
 
@@ -19,30 +20,73 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
     exit 0
 fi
 
+# Remove any containers matching the dcgm-exporter image that do not have the
+# expected name. This cleans up unnamed containers left by older versions of
+# this script and containers whose name no longer matches the current config.
+cleanup_legacy_dcgm_containers() {
+    set +e
+    local legacy
+    legacy=$(docker ps -a --format '{{.ID}} {{.Names}} {{.Image}}' \
+        | grep -i 'dcgm-exporter' \
+        | grep -v " ${DCGM_CONTAINER_NAME} " \
+        | awk '{print $1}')
+    if [ -n "$legacy" ]; then
+        echo "Removing legacy/unnamed DCGM containers: $legacy"
+        docker rm -f $legacy
+    fi
+    set -e
+}
+
+# Ensure the expected DCGM exporter container is running.
+# Strategy:
+#   1. If a correctly-named container is already running with the right image, done.
+#   2. If a container exists (stopped, wrong image, etc.), remove it and recreate.
+#      A stopped container with --restart=always signals a real problem, so we
+#      start fresh rather than blindly restarting stale state.
+#   3. Otherwise, create a new container.
 install_dcgm_exporter() {
-    # Check if a DCGM container is already running on the port
-    if docker ps --format '{{.Ports}}' | grep -q "0.0.0.0:${DCGM_PORT}->"; then
-        echo "DCGM exporter already running on port ${DCGM_PORT}, skipping docker run."
-        # Clean up orphaned containers in "Created" state from prior failed attempts
-        orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
-        if [ -n "$orphaned" ]; then
-            echo "Removing orphaned DCGM containers: $orphaned"
-            docker rm $orphaned || true
-        fi
+    cleanup_legacy_dcgm_containers
+
+    # Clean up orphaned containers in "Created" state from prior failed attempts
+    set +e
+    local orphaned
+    orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
+    if [ -n "$orphaned" ]; then
+        echo "Removing orphaned DCGM containers: $orphaned"
+        docker rm $orphaned
+    fi
+    set -e
+
+    # Check if the named container is already running with the correct image
+    set +e
+    local running_image
+    running_image=$(docker inspect --format '{{.Config.Image}}' "$DCGM_CONTAINER_NAME" 2>/dev/null)
+    local running
+    running=$(docker ps -q --filter "name=^/${DCGM_CONTAINER_NAME}$" --filter "status=running")
+    set -e
+
+    if [ -n "$running" ] && [ "$running_image" = "$DCGM_IMAGE" ]; then
+        echo "DCGM exporter container ${DCGM_CONTAINER_NAME} is already running with correct image, skipping."
         return 0
     fi
 
-    # Check if a named container exists but is stopped
-    if docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$" | grep -q .; then
-        echo "DCGM exporter container exists but is stopped. Starting it."
-        docker start "$DCGM_CONTAINER_NAME"
-        return 0
+    # If a container exists but is not running or has wrong image, remove it.
+    # With --restart=always, a stopped container likely hit a persistent error.
+    # Removing and recreating gives us a clean slate with current config.
+    set +e
+    local existing
+    existing=$(docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$")
+    set -e
+
+    if [ -n "$existing" ]; then
+        echo "Removing existing DCGM container (stopped or wrong image). Will recreate."
+        docker rm -f "$DCGM_CONTAINER_NAME"
     fi
 
-    # No existing container - start a new one
+    # Start a new container
     docker run --name "$DCGM_CONTAINER_NAME" \
             -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p ${DCGM_PORT}:${DCGM_PORT} \
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p "${DCGM_PORT}:${DCGM_PORT}" \
             "$DCGM_IMAGE" -f /etc/dcgm-exporter/custom-counters.csv
 }
 
@@ -70,9 +114,11 @@ function add_scraper() {
 }
 
 # Install DCGM exporter container - failure must not prevent scrape config
+set +e
 if ! install_dcgm_exporter; then
     echo "WARNING: install_dcgm_exporter failed, continuing to configure Prometheus scrape target."
 fi
+set -e
 
 install_yq
 add_scraper

--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
+# Installs yq, dcgm-exporter, and prom config
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SPEC_FILE_ROOT="$script_dir/../files"
 PROM_CONFIG=/opt/prometheus/prometheus.yml
+DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04"
+DCGM_CONTAINER_NAME="dcgm-exporter"
+DCGM_PORT=9400
 
 source "$SPEC_FILE_ROOT/common.sh"
 
@@ -17,30 +20,59 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
 fi
 
 install_dcgm_exporter() {
-    
-    # Run DCGM Exporter in a container
-    docker run -v $SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p 9400:9400 \
-            nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04 -f /etc/dcgm-exporter/custom-counters.csv
+    # Check if a DCGM container is already running on the port
+    if docker ps --format '{{.Ports}}' | grep -q "0.0.0.0:${DCGM_PORT}->"; then
+        echo "DCGM exporter already running on port ${DCGM_PORT}, skipping docker run."
+        # Clean up orphaned containers in "Created" state from prior failed attempts
+        orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
+        if [ -n "$orphaned" ]; then
+            echo "Removing orphaned DCGM containers: $orphaned"
+            docker rm $orphaned || true
+        fi
+        return 0
+    fi
+
+    # Check if a named container exists but is stopped
+    if docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$" | grep -q .; then
+        echo "DCGM exporter container exists but is stopped. Starting it."
+        docker start "$DCGM_CONTAINER_NAME"
+        return 0
+    fi
+
+    # No existing container - start a new one
+    docker run --name "$DCGM_CONTAINER_NAME" \
+            -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p ${DCGM_PORT}:${DCGM_PORT} \
+            "$DCGM_IMAGE" -f /etc/dcgm-exporter/custom-counters.csv
 }
 
 function add_scraper() {
     # If dcgm_exporter is already configured, do not add it again
-    if grep -q "dcgm_exporter" $PROM_CONFIG; then
+    if grep -q "dcgm_exporter" "$PROM_CONFIG" 2>/dev/null; then
         echo "DCGM Exporter is already configured in Prometheus"
         return 0
-    fi    
+    fi
+
+    if [ ! -f "$PROM_CONFIG" ]; then
+        echo "ERROR: $PROM_CONFIG does not exist. Cannot add dcgm_exporter scrape target."
+        return 1
+    fi
+
     INSTANCE_NAME=$(hostname)
 
-    yq eval-all '. as $item ireduce ({}; . *+ $item)' $PROM_CONFIG $SPEC_FILE_ROOT/dcgm_exporter.yml > tmp.yml
-    mv -vf tmp.yml $PROM_CONFIG
+    yq eval-all '. as $item ireduce ({}; . *+ $item)' "$PROM_CONFIG" "$SPEC_FILE_ROOT/dcgm_exporter.yml" > tmp.yml
+    mv -vf tmp.yml "$PROM_CONFIG"
 
     # update the configuration file
-    sed -i "s/instance_name/$INSTANCE_NAME/g" $PROM_CONFIG
+    sed -i "s/instance_name/$INSTANCE_NAME/g" "$PROM_CONFIG"
 
     systemctl restart prometheus
 }
 
-install_dcgm_exporter
+# Install DCGM exporter container - failure must not prevent scrape config
+if ! install_dcgm_exporter; then
+    echo "WARNING: install_dcgm_exporter failed, continuing to configure Prometheus scrape target."
+fi
+
 install_yq
 add_scraper

--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 # Installs yq, dcgm-exporter, and prom config
-set -ex
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SPEC_FILE_ROOT="$script_dir/../files"
 PROM_CONFIG=/opt/prometheus/prometheus.yml
 DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04"
 DCGM_CONTAINER_NAME="dcgm-exporter"
-DCGM_PORT=$(/opt/cycle/jetpack/bin/jetpack config cyclecloud.monitoring.dcgm_exporter_port 9400)
+DCGM_PORT=9400
 
 source "$SPEC_FILE_ROOT/common.sh"
 
@@ -20,73 +19,30 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
     exit 0
 fi
 
-# Remove any containers matching the dcgm-exporter image that do not have the
-# expected name. This cleans up unnamed containers left by older versions of
-# this script and containers whose name no longer matches the current config.
-cleanup_legacy_dcgm_containers() {
-    set +e
-    local legacy
-    legacy=$(docker ps -a --format '{{.ID}} {{.Names}} {{.Image}}' \
-        | grep -i 'dcgm-exporter' \
-        | grep -v " ${DCGM_CONTAINER_NAME} " \
-        | awk '{print $1}')
-    if [ -n "$legacy" ]; then
-        echo "Removing legacy/unnamed DCGM containers: $legacy"
-        docker rm -f $legacy
-    fi
-    set -e
-}
-
-# Ensure the expected DCGM exporter container is running.
-# Strategy:
-#   1. If a correctly-named container is already running with the right image, done.
-#   2. If a container exists (stopped, wrong image, etc.), remove it and recreate.
-#      A stopped container with --restart=always signals a real problem, so we
-#      start fresh rather than blindly restarting stale state.
-#   3. Otherwise, create a new container.
 install_dcgm_exporter() {
-    cleanup_legacy_dcgm_containers
-
-    # Clean up orphaned containers in "Created" state from prior failed attempts
-    set +e
-    local orphaned
-    orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
-    if [ -n "$orphaned" ]; then
-        echo "Removing orphaned DCGM containers: $orphaned"
-        docker rm $orphaned
-    fi
-    set -e
-
-    # Check if the named container is already running with the correct image
-    set +e
-    local running_image
-    running_image=$(docker inspect --format '{{.Config.Image}}' "$DCGM_CONTAINER_NAME" 2>/dev/null)
-    local running
-    running=$(docker ps -q --filter "name=^/${DCGM_CONTAINER_NAME}$" --filter "status=running")
-    set -e
-
-    if [ -n "$running" ] && [ "$running_image" = "$DCGM_IMAGE" ]; then
-        echo "DCGM exporter container ${DCGM_CONTAINER_NAME} is already running with correct image, skipping."
+    # Check if a DCGM container is already running on the port
+    if docker ps --format '{{.Ports}}' | grep -q "0.0.0.0:${DCGM_PORT}->"; then
+        echo "DCGM exporter already running on port ${DCGM_PORT}, skipping docker run."
+        # Clean up orphaned containers in "Created" state from prior failed attempts
+        orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
+        if [ -n "$orphaned" ]; then
+            echo "Removing orphaned DCGM containers: $orphaned"
+            docker rm $orphaned || true
+        fi
         return 0
     fi
 
-    # If a container exists but is not running or has wrong image, remove it.
-    # With --restart=always, a stopped container likely hit a persistent error.
-    # Removing and recreating gives us a clean slate with current config.
-    set +e
-    local existing
-    existing=$(docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$")
-    set -e
-
-    if [ -n "$existing" ]; then
-        echo "Removing existing DCGM container (stopped or wrong image). Will recreate."
-        docker rm -f "$DCGM_CONTAINER_NAME"
+    # Check if a named container exists but is stopped
+    if docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$" | grep -q .; then
+        echo "DCGM exporter container exists but is stopped. Starting it."
+        docker start "$DCGM_CONTAINER_NAME"
+        return 0
     fi
 
-    # Start a new container
+    # No existing container - start a new one
     docker run --name "$DCGM_CONTAINER_NAME" \
             -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p "${DCGM_PORT}:${DCGM_PORT}" \
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p ${DCGM_PORT}:${DCGM_PORT} \
             "$DCGM_IMAGE" -f /etc/dcgm-exporter/custom-counters.csv
 }
 
@@ -114,11 +70,9 @@ function add_scraper() {
 }
 
 # Install DCGM exporter container - failure must not prevent scrape config
-set +e
 if ! install_dcgm_exporter; then
     echo "WARNING: install_dcgm_exporter failed, continuing to configure Prometheus scrape target."
 fi
-set -e
 
 install_yq
 add_scraper

--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -63,7 +63,7 @@ function install_dcgm_exporter() {
 
     docker run --name "$DCGM_CONTAINER_NAME" \
             -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p "${DCGM_PORT}:${DCGM_PORT}" \
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p "${DCGM_PORT}:9400" \
             "$DCGM_IMAGE" -f /etc/dcgm-exporter/custom-counters.csv
 }
 

--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Installs yq, dcgm-exporter, and prom config
+set -ex
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SPEC_FILE_ROOT="$script_dir/../files"
 PROM_CONFIG=/opt/prometheus/prometheus.yml
 DCGM_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04"
 DCGM_CONTAINER_NAME="dcgm-exporter"
-DCGM_PORT=9400
+DCGM_PORT=$(/opt/cycle/jetpack/bin/jetpack config cyclecloud.monitoring.dcgm_exporter_port 9400)
 
 source "$SPEC_FILE_ROOT/common.sh"
 
@@ -19,30 +20,82 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
     exit 0
 fi
 
+# Docker helper functions
+# - Check if a named container is running. Returns 0 if running, 1 otherwise.
+is_container_running() {
+    local name="$1"
+    if docker ps -q --filter "name=^/${name}$" --filter "status=running" | grep -q .; then
+        return 0
+    fi
+    return 1
+}
+
+# - Get the image of a named container. Prints empty string if container does not exist.
+get_container_image() {
+    local name="$1"
+    docker inspect --format '{{.Config.Image}}' "$name" 2>/dev/null || true
+}
+
+#  -Remove containers matching a docker ps filter. No-op if none match.
+remove_containers_by_filter() {
+    local matches
+    matches=$(docker ps -a -q "$@") || true
+    if [ -n "$matches" ]; then
+        echo "Removing containers: $matches"
+        docker rm -f $matches
+    fi
+}
+
+# Cleanup functions
+# - Remove dcgm-exporter containers that do not have the expected name.
+# - Cleans up unnamed containers left by older versions of this script and
+#   containers whose name no longer matches the current config.
+cleanup_legacy_containers() {
+    local legacy
+    legacy=$(docker ps -a --format '{{.ID}} {{.Names}} {{.Image}}' \
+        | grep -i 'dcgm-exporter' \
+        | grep -v " ${DCGM_CONTAINER_NAME} " \
+        | awk '{print $1}') || true
+    if [ -n "$legacy" ]; then
+        echo "Removing legacy/unnamed DCGM containers: $legacy"
+        docker rm -f $legacy
+    fi
+}
+
+# Remove containers stuck in "Created" state from prior failed docker run attempts.
+cleanup_orphaned_containers() {
+    remove_containers_by_filter --filter "ancestor=${DCGM_IMAGE}" --filter "status=created"
+}
+
+# Main functions
+# Ensure the expected DCGM exporter container is running.
+# - Clean up legacy and orphaned containers.
+# - If correctly-named container is running with the right image, done.
+# - If a container exists (stopped, wrong image, etc.), remove it and recreate.
+#   A stopped container with --restart=always signals a persistent error, so
+#   we start fresh rather than blindly restarting stale state.
+# - Otherwise, create a new container.
 install_dcgm_exporter() {
-    # Check if a DCGM container is already running on the port
-    if docker ps --format '{{.Ports}}' | grep -q "0.0.0.0:${DCGM_PORT}->"; then
-        echo "DCGM exporter already running on port ${DCGM_PORT}, skipping docker run."
-        # Clean up orphaned containers in "Created" state from prior failed attempts
-        orphaned=$(docker ps -a -q --filter "ancestor=${DCGM_IMAGE}" --filter "status=created")
-        if [ -n "$orphaned" ]; then
-            echo "Removing orphaned DCGM containers: $orphaned"
-            docker rm $orphaned || true
-        fi
+    cleanup_legacy_containers
+    cleanup_orphaned_containers
+
+    local current_image
+    current_image=$(get_container_image "$DCGM_CONTAINER_NAME")
+
+    if is_container_running "$DCGM_CONTAINER_NAME" && [ "$current_image" = "$DCGM_IMAGE" ]; then
+        echo "DCGM exporter container ${DCGM_CONTAINER_NAME} is already running with correct image, skipping."
         return 0
     fi
 
-    # Check if a named container exists but is stopped
-    if docker ps -a -q --filter "name=^/${DCGM_CONTAINER_NAME}$" | grep -q .; then
-        echo "DCGM exporter container exists but is stopped. Starting it."
-        docker start "$DCGM_CONTAINER_NAME"
-        return 0
+    # Remove stale container if one exists (wrong image, stopped, etc.)
+    if [ -n "$current_image" ]; then
+        echo "Removing existing DCGM container (stopped or wrong image). Will recreate."
+        docker rm -f "$DCGM_CONTAINER_NAME"
     fi
 
-    # No existing container - start a new one
     docker run --name "$DCGM_CONTAINER_NAME" \
             -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
-            -d --gpus all --cap-add SYS_ADMIN --restart always -p ${DCGM_PORT}:${DCGM_PORT} \
+            -d --gpus all --cap-add SYS_ADMIN --restart always -p "${DCGM_PORT}:${DCGM_PORT}" \
             "$DCGM_IMAGE" -f /etc/dcgm-exporter/custom-counters.csv
 }
 

--- a/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
+++ b/specs/default/cluster-init/scripts/40_dcgm_exporter.sh
@@ -20,9 +20,9 @@ if ! nvidia-smi -L > /dev/null 2>&1; then
     exit 0
 fi
 
-# Docker helper functions
+# Docker helpers
 # - Check if a named container is running. Returns 0 if running, 1 otherwise.
-is_container_running() {
+function is_container_running() {
     local name="$1"
     if docker ps -q --filter "name=^/${name}$" --filter "status=running" | grep -q .; then
         return 0
@@ -31,67 +31,35 @@ is_container_running() {
 }
 
 # - Get the image of a named container. Prints empty string if container does not exist.
-get_container_image() {
+function get_container_image() {
     local name="$1"
     docker inspect --format '{{.Config.Image}}' "$name" 2>/dev/null || true
 }
 
-#  -Remove containers matching a docker ps filter. No-op if none match.
-remove_containers_by_filter() {
+# - Remove ALL containers matching the dcgm-exporter image
+function cleanup_all_dcgm_containers() {
     local matches
-    matches=$(docker ps -a -q "$@") || true
+    matches=$(docker ps -a --format '{{.ID}} {{.Image}}' \
+        | grep -i 'dcgm-exporter' \
+        | awk '{print $1}') || true
     if [ -n "$matches" ]; then
-        echo "Removing containers: $matches"
+        echo "Removing all DCGM exporter containers: $matches"
         docker rm -f $matches
     fi
 }
 
-# Cleanup functions
-# - Remove dcgm-exporter containers that do not have the expected name.
-# - Cleans up unnamed containers left by older versions of this script and
-#   containers whose name no longer matches the current config.
-cleanup_legacy_containers() {
-    local legacy
-    legacy=$(docker ps -a --format '{{.ID}} {{.Names}} {{.Image}}' \
-        | grep -i 'dcgm-exporter' \
-        | grep -v " ${DCGM_CONTAINER_NAME} " \
-        | awk '{print $1}') || true
-    if [ -n "$legacy" ]; then
-        echo "Removing legacy/unnamed DCGM containers: $legacy"
-        docker rm -f $legacy
-    fi
-}
-
-# Remove containers stuck in "Created" state from prior failed docker run attempts.
-cleanup_orphaned_containers() {
-    remove_containers_by_filter --filter "ancestor=${DCGM_IMAGE}" --filter "status=created"
-}
-
 # Main functions
 # Ensure the expected DCGM exporter container is running.
-# - Clean up legacy and orphaned containers.
-# - If correctly-named container is running with the right image, done.
-# - If a container exists (stopped, wrong image, etc.), remove it and recreate.
-#   A stopped container with --restart=always signals a persistent error, so
-#   we start fresh rather than blindly restarting stale state.
-# - Otherwise, create a new container.
-install_dcgm_exporter() {
-    cleanup_legacy_containers
-    cleanup_orphaned_containers
-
-    local current_image
-    current_image=$(get_container_image "$DCGM_CONTAINER_NAME")
-
-    if is_container_running "$DCGM_CONTAINER_NAME" && [ "$current_image" = "$DCGM_IMAGE" ]; then
+# If the correct container is already running, this is a no-op.
+# Otherwise, remove everything dcgm-related and start fresh.
+function install_dcgm_exporter() {
+    if is_container_running "$DCGM_CONTAINER_NAME" \
+        && [ "$(get_container_image "$DCGM_CONTAINER_NAME")" = "$DCGM_IMAGE" ]; then
         echo "DCGM exporter container ${DCGM_CONTAINER_NAME} is already running with correct image, skipping."
         return 0
     fi
 
-    # Remove stale container if one exists (wrong image, stopped, etc.)
-    if [ -n "$current_image" ]; then
-        echo "Removing existing DCGM container (stopped or wrong image). Will recreate."
-        docker rm -f "$DCGM_CONTAINER_NAME"
-    fi
+    cleanup_all_dcgm_containers
 
     docker run --name "$DCGM_CONTAINER_NAME" \
             -v "$SPEC_FILE_ROOT/custom_dcgm_counters.csv:/etc/dcgm-exporter/custom-counters.csv" \
@@ -113,8 +81,10 @@ function add_scraper() {
 
     INSTANCE_NAME=$(hostname)
 
-    yq eval-all '. as $item ireduce ({}; . *+ $item)' "$PROM_CONFIG" "$SPEC_FILE_ROOT/dcgm_exporter.yml" > tmp.yml
-    mv -vf tmp.yml "$PROM_CONFIG"
+    local tmpfile
+    tmpfile=$(mktemp)
+    yq eval-all '. as $item ireduce ({}; . *+ $item)' "$PROM_CONFIG" "$SPEC_FILE_ROOT/dcgm_exporter.yml" > "$tmpfile"
+    mv -vf "$tmpfile" "$PROM_CONFIG"
 
     # update the configuration file
     sed -i "s/instance_name/$INSTANCE_NAME/g" "$PROM_CONFIG"


### PR DESCRIPTION
Fixes for issues seen on GB200 cluster:

- More robustly handle pre-existing containers
- Use named container for idempotency
- Clean orphaned containers
- Decouple installing dcgm-exporter with the scraper install
- Check that `prometheus.yml` exists before merging