### PR TITLE
fix node level dashboard queries to include exact instance name match

### DIFF
--- a/infra/dashboards/cluster_nodearray_overview.json
+++ b/infra/dashboards/cluster_nodearray_overview.json
@@ -74,7 +74,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -109,7 +110,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -118,7 +119,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by (nodearray)(node_time_seconds{nodearray=~\"$nodearray\", cluster=\"$cluster\"} - node_boot_time_seconds{nodearray=~\"$nodearray\", cluster=\"$cluster\"})",
+          "expr": "avg by (nodearray)(node_time_seconds{nodearray=~\"^$nodearray$\", cluster=\"$cluster\"} - node_boot_time_seconds{nodearray=~\"^$nodearray$\", cluster=\"$cluster\"})",
           "format": "table",
           "instant": true,
           "legendFormat": "{{nodearray}}",
@@ -158,7 +159,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#000c5dfc"
+                "color": "#000c5dfc",
+                "value": 0
               },
               {
                 "color": "dark-blue",
@@ -209,7 +211,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -217,7 +219,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 - (avg by (nodearray) (rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode=\"idle\",cluster=\"$cluster\"}[$__rate_interval])) * 100)",
+          "expr": "100 - (avg by (nodearray) (rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode=\"idle\",cluster=\"$cluster\"}[$__rate_interval])) * 100)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -260,7 +262,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "#EAB839",
@@ -298,7 +301,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -307,7 +310,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(100 - avg by (nodearray)(node_filesystem_avail_bytes{nodearray=~\"$nodearray\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / avg by (nodearray)(node_filesystem_size_bytes{nodearray=~\"$nodearray\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}))",
+          "expr": "(100 - avg by (nodearray)(node_filesystem_avail_bytes{nodearray=~\"^$nodearray$\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / avg by (nodearray)(node_filesystem_size_bytes{nodearray=~\"^$nodearray$\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}))",
           "format": "table",
           "instant": true,
           "legendFormat": "{{instance}}",
@@ -354,6 +357,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -371,7 +375,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -406,7 +411,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -414,7 +419,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
           "hide": true,
           "legendFormat": "CPU {{cpu}}",
           "range": true,
@@ -426,7 +431,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - avg by (instance,cpu) (rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\"}[$__rate_interval])))",
+          "expr": "100 * (1 - avg by (instance,cpu) (rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\"}[$__rate_interval])))",
           "format": "time_series",
           "hide": true,
           "instant": false,
@@ -440,7 +445,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - avg by (instance, cpu) (rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\"}[$__rate_interval])))",
+          "expr": "100 * (1 - avg by (instance, cpu) (rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode='idle', instance=~\"$instance\", cpu=~\"^$cpu$\", cluster=\"$cluster\"}[$__rate_interval])))",
           "hide": true,
           "instant": false,
           "legendFormat": "__auto",
@@ -453,7 +458,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - avg by (nodearray)(rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode='idle', cluster=\"$cluster\"}[$__rate_interval])))",
+          "expr": "100 * (1 - avg by (nodearray)(rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode='idle', cluster=\"$cluster\"}[$__rate_interval])))",
           "hide": true,
           "instant": false,
           "legendFormat": "{{nodearray}}",
@@ -466,8 +471,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 - (avg by (nodearray) (rate(node_cpu_seconds_total{nodearray=~\"$nodearray\",mode=\"idle\",cluster=\"$cluster\"}[$__rate_interval])) * 100)",
-          "hide": false,
+          "expr": "100 - (avg by (nodearray) (rate(node_cpu_seconds_total{nodearray=~\"^$nodearray$\",mode=\"idle\",cluster=\"$cluster\"}[$__rate_interval])) * 100)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -513,6 +517,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -527,7 +532,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -562,7 +568,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -570,7 +576,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(irate(node_disk_io_time_seconds_total{nodearray=~\"$nodearray\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval]))",
+          "expr": "avg by (nodearray)(irate(node_disk_io_time_seconds_total{nodearray=~\"^$nodearray$\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval]))",
           "legendFormat": "{{nodearray}} {{device}}",
           "range": true,
           "refId": "A"
@@ -615,6 +621,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -631,7 +638,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -667,7 +675,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -675,7 +683,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (nodearray)(node_memory_memavailable_bytes{nodearray=~\"$nodearray\", cluster=\"$cluster\"}) / avg by (nodearray)(node_memory_memtotal_bytes{nodearray=~\"$nodearray\",cluster=\"$cluster\"})))",
+          "expr": "(100 * (1 - avg by (nodearray)(node_memory_memavailable_bytes{nodearray=~\"^$nodearray$\", cluster=\"$cluster\"}) / avg by (nodearray)(node_memory_memtotal_bytes{nodearray=~\"^$nodearray$\",cluster=\"$cluster\"})))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -721,6 +729,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -735,7 +744,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -783,7 +793,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -791,7 +801,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(irate(node_mountstats_nfs_total_read_bytes_total{cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "avg by (nodearray)(irate(node_mountstats_nfs_total_read_bytes_total{nodearray=~\"^$nodearray$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{nodearray}} {{export}} - read",
           "range": true,
           "refId": "A"
@@ -802,7 +812,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(irate(node_mountstats_nfs_total_write_bytes_total{cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "avg by (nodearray)(irate(node_mountstats_nfs_total_write_bytes_total{nodearray=~\"^$nodearray$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{nodearray}} {{export}} - write",
           "range": true,
           "refId": "B"
@@ -847,6 +857,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -861,7 +872,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -904,7 +916,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -912,8 +924,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(irate(node_vmstat_pgmajfault{nodearray=~\"$nodearray\",cluster=\"$cluster\"}[$__rate_interval]))",
-          "hide": false,
+          "expr": "avg by (nodearray)(irate(node_vmstat_pgmajfault{nodearray=~\"^$nodearray$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -959,6 +970,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -973,7 +985,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -1017,7 +1030,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1025,7 +1038,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(rate(node_network_receive_bytes_total{nodearray=~\"$nodearray\",device='eth0',cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "avg by (nodearray)(rate(node_network_receive_bytes_total{nodearray=~\"^$nodearray$\",device='eth0',cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{nodearray}} - receive",
           "range": true,
           "refId": "A"
@@ -1036,8 +1049,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray)(rate(node_network_transmit_bytes_total{nodearray=~\"$nodearray\",device='eth0',cluster=\"$cluster\"}[$__rate_interval]))",
-          "hide": false,
+          "expr": "avg by (nodearray)(rate(node_network_transmit_bytes_total{nodearray=~\"^$nodearray$\",device='eth0',cluster=\"$cluster\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{nodearray}} - transmit",
           "range": true,
@@ -1083,6 +1095,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1097,7 +1110,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1145,7 +1159,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1153,7 +1167,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": " avg by (nodearray,device)(irate(node_disk_read_bytes_total{nodearray=~\"$nodearray\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": " avg by (nodearray,device)(irate(node_disk_read_bytes_total{nodearray=~\"^$nodearray$\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{nodearray}} {{device}} -read",
           "range": true,
           "refId": "A"
@@ -1164,7 +1178,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg by (nodearray,device)(irate(node_disk_written_bytes_total{nodearray=~\"$nodearray\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "avg by (nodearray,device)(irate(node_disk_written_bytes_total{nodearray=~\"^$nodearray$\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{nodearray}} {{device}}  - write",
           "range": true,
           "refId": "B"
@@ -1176,7 +1190,7 @@
   ],
   "preload": false,
   "refresh": "5s",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
@@ -1216,6 +1230,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1240,6 +1255,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
@@ -1265,6 +1281,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1289,6 +1306,7 @@
         },
         "refresh": 1,
         "regex": "/^(?!dm-|loop|tmpfs)/",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1313,6 +1331,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1336,6 +1355,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1359,12 +1379,13 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
         "current": {
-          "text": "ams261151107013",
-          "value": "ams261151107013"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
@@ -1382,6 +1403,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1410,6 +1432,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]

--- a/infra/dashboards/gpu_level.json
+++ b/infra/dashboards/gpu_level.json
@@ -69,6 +69,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -76,7 +79,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -96,14 +100,6 @@
       "id": 2020,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "frameIndex": 3,
         "showHeader": true,
         "sortBy": [
@@ -113,7 +109,7 @@
           }
         ]
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -122,7 +118,6 @@
           },
           "editorMode": "code",
           "expr": "dcgm_fi_dev_gpu_util{instance=~\"$instance\", cluster=\"$cluster\", gpu=\"0\"}",
-          "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -184,7 +179,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#000c5dfc"
+                "color": "#000c5dfc",
+                "value": 0
               },
               {
                 "color": "dark-blue",
@@ -235,7 +231,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -243,7 +239,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{instance=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}",
+          "expr": "dcgm_fi_dev_gpu_util{instance=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"$gpu\"}",
           "instant": false,
           "legendFormat": "{{instance}} - GPU {{gpu}}",
           "range": true,
@@ -271,7 +267,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -309,7 +306,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -344,7 +341,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "#EAB839",
@@ -382,7 +380,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -425,7 +423,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#299c46"
+                "color": "#299c46",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -470,7 +469,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -523,6 +522,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -540,7 +540,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -577,7 +578,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -630,6 +631,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -645,7 +647,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -682,7 +685,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -690,7 +693,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -717,6 +720,9 @@
               "type": "auto"
             },
             "filterable": true,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -724,7 +730,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -782,19 +789,16 @@
       "id": 2050,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
+        "enablePagination": true,
         "showHeader": true,
-        "sortBy": []
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "GPU"
+          }
+        ]
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -803,11 +807,9 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{instance=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
-          "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
@@ -815,49 +817,76 @@
       "title": "Last GPU XID Code",
       "transformations": [
         {
-          "id": "reduce",
+          "id": "filterFieldsByName",
           "options": {
-            "includeTimeField": false,
-            "mode": "reduceFields",
-            "reducers": [
-              "lastNotNull"
-            ]
+            "include": {
+              "names": [
+                "device",
+                "gpu",
+                "hostname",
+                "Value",
+                "instance"
+              ]
+            }
           }
         },
         {
-          "id": "filterFieldsByName",
+          "id": "groupBy",
           "options": {
-            "byVariable": false,
-            "include": {
-              "names": [
-                "gpu",
-                "instance",
-                "Value"
-              ]
+            "fields": {
+              "GPU ID": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Value": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "device": {
+                "aggregations": []
+              },
+              "gpu": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "gpu_id": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "hostname": {
+                "aggregations": []
+              },
+              "instance": {
+                "aggregations": []
+              },
+              "time_stamp": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "groupby"
+              }
             }
           }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": {
-              "Trend #A": false
-            },
+            "excludeByName": {},
             "includeByName": {},
             "indexByName": {
-              "Trend #A": 2,
+              "Value (last)": 2,
               "gpu": 1,
               "instance": 0
             },
             "renameByName": {
-              "Trend #A": "XID Code",
               "Value": "XID Code",
               "Value (last)": "XID Code",
               "gpu": "GPU",
               "gpu_id": "GPU ID",
               "hostname": "Instance",
               "instance": "Instance",
-              "instance (last)": "Instance",
               "time_stamp": "Time Stamp",
               "time_stamp (last)": "Time Stamp"
             }
@@ -896,6 +925,9 @@
               "type": "auto"
             },
             "filterable": true,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "decimals": 0,
@@ -906,7 +938,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -977,19 +1010,11 @@
       "id": 2051,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
+        "enablePagination": true,
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1104,6 +1129,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1119,7 +1145,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1156,7 +1183,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1164,7 +1191,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1209,6 +1236,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1224,7 +1252,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1258,7 +1287,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1266,7 +1295,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1311,6 +1340,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1326,7 +1356,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1363,7 +1394,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1371,7 +1402,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1416,6 +1447,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1431,7 +1463,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1465,7 +1498,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1473,7 +1506,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1518,6 +1551,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1533,7 +1567,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1566,7 +1601,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1575,7 +1610,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1620,6 +1655,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1635,7 +1671,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1669,7 +1706,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1677,7 +1714,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1722,6 +1759,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1737,7 +1775,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1770,7 +1809,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1779,7 +1818,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{instance=~\"^$instance$\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "{{instance}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -1791,7 +1830,7 @@
   ],
   "preload": false,
   "refresh": "5s",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
@@ -1831,6 +1870,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1854,6 +1894,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
@@ -1879,6 +1920,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1903,6 +1945,7 @@
         },
         "refresh": 1,
         "regex": "/^(?!dm-|loop|tmpfs)/",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1926,6 +1969,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1949,6 +1993,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1972,6 +2017,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1995,6 +2041,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -2022,6 +2069,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]

--- a/infra/dashboards/node_level.json
+++ b/infra/dashboards/node_level.json
@@ -69,6 +69,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -76,7 +79,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -96,14 +100,6 @@
       "id": 2017,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "frameIndex": 3,
         "showHeader": true,
         "sortBy": [
@@ -113,7 +109,7 @@
           }
         ]
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -122,7 +118,6 @@
           },
           "editorMode": "code",
           "expr": "node_uname_info{instance=\"$instance\", cluster=\"$cluster\"}",
-          "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -216,6 +211,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -233,7 +229,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -268,7 +265,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -276,8 +273,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode='idle', instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))",
-          "hide": false,
+          "expr": "100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -293,7 +289,6 @@
         "type": "prometheus",
         "uid": "${Datasource}"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -306,7 +301,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "#EAB839",
@@ -344,7 +340,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -353,7 +349,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (instance)(100 - (node_filesystem_avail_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"})",
+          "expr": "max by (instance)(100 - (node_filesystem_avail_bytes{instance=~\"^$instance$\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=~\"^$instance$\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"})",
           "format": "table",
           "instant": true,
           "legendFormat": "{{instance}}",
@@ -383,7 +379,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -418,7 +415,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -474,6 +471,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -490,7 +488,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -526,7 +525,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -580,6 +579,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -594,7 +594,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -629,7 +630,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -637,7 +638,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{instance}} {{device}}",
           "range": true,
           "refId": "A"
@@ -682,6 +683,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -696,7 +698,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -739,7 +742,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -747,8 +750,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
-          "hide": false,
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -794,6 +796,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -808,7 +811,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -856,7 +860,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -864,7 +868,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} {{export}} - read",
           "range": true,
           "refId": "A"
@@ -875,7 +879,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} {{export}} - write",
           "range": true,
           "refId": "B"
@@ -920,6 +924,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -934,7 +939,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -982,7 +988,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -990,7 +996,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} {{device}} -read",
           "range": true,
           "refId": "A"
@@ -1001,7 +1007,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{instance}} {{device}} - write",
           "range": true,
           "refId": "B"
@@ -1046,6 +1052,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1060,7 +1067,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -1104,7 +1112,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.9",
+      "pluginVersion": "12.4.3",
       "targets": [
         {
           "datasource": {
@@ -1112,7 +1120,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -1123,8 +1131,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
-          "hide": false,
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
           "range": true,
@@ -1137,7 +1144,7 @@
   ],
   "preload": false,
   "refresh": "5s",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
@@ -1177,6 +1184,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1203,6 +1211,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1226,6 +1235,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1250,6 +1260,7 @@
         },
         "refresh": 1,
         "regex": "/^(?!dm-|loop|tmpfs)/",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1274,6 +1285,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1297,6 +1309,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
@@ -1320,12 +1333,13 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
         "current": {
-          "text": "ams261131305005",
-          "value": "ams261131305005"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
@@ -1343,6 +1357,7 @@
         },
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]


### PR DESCRIPTION
Bug in dashboard where panels were filtered on all instances that had the chosen instance in their name for example, filtering on ccw-gpu-1 had all panels filter on ccw-gpu-1*, so ccw-gpu-10, ccw-gpu-11 etc.